### PR TITLE
check toram was used to calculate live root space

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mx-snapshot (24.6) mx; urgency=medium
+
+  * Check whether linuxfs was copied to the ram during the live boot
+
+ -- fehlix <fehlix@mxlinux.org>  Wed, 05 Jun 2024 14:45:24 -0400
+
 mx-snapshot (24.5) mx; urgency=medium
 
   * Run editor as user when editing exclusion file if the editor elevates

--- a/settings.cpp
+++ b/settings.cpp
@@ -349,6 +349,12 @@ quint64 Settings::getLiveRootSpace()
     // Load some live variables
     QSettings livesettings("/live/config/initrd.out", QSettings::NativeFormat);
     QString sqfile_full = livesettings.value("SQFILE_FULL", "/live/boot-dev/antiX/linuxfs").toString();
+    QString toram_mp = livesettings.value("TORAM_MP", "/live/to-ram").toString();
+    QString sqfile_path = livesettings.value("SQFILE_PATH", "antiX").toString().remove(QRegularExpression("^/+"));
+    QString sqfile_name = livesettings.value("SQFILE_NAME", "linuxfs").toString();
+    if (!toram_mp.isEmpty() && QFileInfo::exists(toram_mp + "/" + sqfile_path  + "/" + sqfile_name)) {
+        sqfile_full = toram_mp + "/" + sqfile_path  + "/" + sqfile_name;
+    }
 
     // Get compression factor by reading the linuxfs squasfs file, if available
     QString linuxfs_compression_type


### PR DESCRIPTION
to avoid warning of unknown compression type and perhaps a "better" estimated used space on root.
