### PR TITLE
validate home folders before doing exclusions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+mx-snapshot (26.04.2) mx; urgency=medium
+
+  * change way users are collected
+  * eliminates some non existing home folders when system users are 
+    configured as user-level users.
+
+ -- Dolphin Oracle <dolphinoracle@gmail.com>  Sun, 19 Apr 2026 14:19:14 -0400
+
 mx-snapshot (26.04.1) mx; urgency=medium
 
   * Update initrd helper scripts

--- a/src/systeminfo.cpp
+++ b/src/systeminfo.cpp
@@ -18,9 +18,16 @@ bool SystemInfo::isLive()
 
 QStringList SystemInfo::listUsers()
 {
-    QStringList users = Cmd().getOut("lslogins --noheadings -u -o user", Cmd::QuietMode::Yes)
-                            .split('\n', Qt::SkipEmptyParts);
-    users.removeAll(QStringLiteral("root"));
+    const QStringList lines = Cmd().getOut("lslogins --noheadings -u -o user,HOMEDIR", Cmd::QuietMode::Yes)
+                                  .split('\n', Qt::SkipEmptyParts);
+    QStringList users;
+    for (const QString &line : lines) {
+        const QString trimmed = line.trimmed();
+        const int sep = trimmed.indexOf(' ');
+        if (sep > 0 && trimmed.mid(sep + 1).trimmed().startsWith("/home/")) {
+            users << trimmed.left(sep);
+        }
+    }
     return users;
 }
 


### PR DESCRIPTION
prevents a situation where a system user might be listed with lslogins -u from generating a invalid regex for the wildcards setup in the mksquashfs area.